### PR TITLE
SALESDEMO-2696: Comparison tab is now showing up without errors

### DIFF
--- a/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/SiteimproveContentFeedbackProvider.java
+++ b/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/SiteimproveContentFeedbackProvider.java
@@ -70,7 +70,7 @@ public class SiteimproveContentFeedbackProvider implements FeedbackProvider {
       PageDocument previewPage = findPage(settings, content, true);
       PageDocument livePage = null;
       ContentQualitySummaryDocument previewContentQualitySummary = getContentQualitySummary(settings, previewPage, true);
-      if (previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getId()!=  null) {
+      if (previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen()!=  null) {
         lastPreviewUpdate = previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();
       }
         generatePreviewTab(items, previewContentQualitySummary, lastPreviewUpdate, lastLiveUpdate);

--- a/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/SiteimproveContentFeedbackProvider.java
+++ b/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/SiteimproveContentFeedbackProvider.java
@@ -70,20 +70,20 @@ public class SiteimproveContentFeedbackProvider implements FeedbackProvider {
       PageDocument previewPage = findPage(settings, content, true);
       PageDocument livePage = null;
       ContentQualitySummaryDocument previewContentQualitySummary = getContentQualitySummary(settings, previewPage, true);
-      lastPreviewUpdate = previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();
-      generatePreviewTab(items, previewContentQualitySummary);
-
-      //when not published there is no summary for live document
-      if (content.getRepository().getPublicationService().isPublished(content)) {
-        livePage = findPage(settings, content, false);
-        ContentQualitySummaryDocument liveContentQualitySummary = getContentQualitySummary(settings, livePage, false);
-        lastLiveUpdate = liveContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();
-        generateLiveTab(items, previewContentQualitySummary, liveContentQualitySummary, lastPreviewUpdate, lastLiveUpdate);
+      if (previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getId()!=  null) {
+        lastPreviewUpdate = previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();
       }
-      else {
-        items.add(FeedbackItemFactory.createEmptyItem(SiteimproveFeedbackTabs.COMPARISON));
-      }
+        generatePreviewTab(items, previewContentQualitySummary, lastPreviewUpdate, lastLiveUpdate);
 
+        //when not published there is no summary for live document
+        if (content.getRepository().getPublicationService().isPublished(content)) {
+          livePage = findPage(settings, content, false);
+          ContentQualitySummaryDocument liveContentQualitySummary = getContentQualitySummary(settings, livePage, false);
+          lastLiveUpdate = liveContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();
+          generateLiveTab(items, previewContentQualitySummary, liveContentQualitySummary, lastPreviewUpdate, lastLiveUpdate);
+        } else {
+          items.add(FeedbackItemFactory.createEmptyItem(SiteimproveFeedbackTabs.COMPARISON));
+        }
       //add footer
       items.add(new FooterFeedbackItem(lastPreviewUpdate, lastLiveUpdate, previewPage, livePage));
     } catch (Exception e) {
@@ -95,12 +95,12 @@ public class SiteimproveContentFeedbackProvider implements FeedbackProvider {
 
   /**
    * Generates the preview tab.
-   *
-   * @param items                        the list of items available for Siteimprove
+   *  @param items                        the list of items available for Siteimprove
    * @param previewContentQualitySummary the summary document which contains all data to display feedback for
+   * @param lastPreviewUpdate
+   * @param lastLiveUpdate
    */
-  private void generatePreviewTab(List<FeedbackItem> items, ContentQualitySummaryDocument previewContentQualitySummary) {
-    long lastPreviewUpdate = previewContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();
+  private void generatePreviewTab(List<FeedbackItem> items, ContentQualitySummaryDocument previewContentQualitySummary, long lastPreviewUpdate, long lastLiveUpdate) {
     GaugeFeedbackItem gaugeItem = GaugeFeedbackItem.builder()
             .withCollection(SiteimproveFeedbackTabs.PREVIEW)
             .withTitle("siteimprove_digitalCertaintyIndex")

--- a/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/SiteimproveContentFeedbackProvider.java
+++ b/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/SiteimproveContentFeedbackProvider.java
@@ -74,7 +74,7 @@ public class SiteimproveContentFeedbackProvider implements FeedbackProvider {
       generatePreviewTab(items, previewContentQualitySummary);
 
       //when not published there is no summary for live document
-      if (!content.getRepository().getPublicationService().isPublished(content)) {
+      if (content.getRepository().getPublicationService().isPublished(content)) {
         livePage = findPage(settings, content, false);
         ContentQualitySummaryDocument liveContentQualitySummary = getContentQualitySummary(settings, livePage, false);
         lastLiveUpdate = liveContentQualitySummary.getPageDetailsDocument().getSummary().getPage().getLastSeen().getTime();

--- a/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/service/ContentLinkBuilder.java
+++ b/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/service/ContentLinkBuilder.java
@@ -23,8 +23,8 @@ import java.util.List;
  */
 public class ContentLinkBuilder {
   private static final Logger LOG = LoggerFactory.getLogger(ContentLinkBuilder.class);
-  private static final String PREVIEW_URL_SERVICE_URL = "blueprint/servlet/internal/service/url";
-  private static final String LIVE_URL_SERVICE_URL = "blueprint/servlet/internal/service/url";
+  private static final String PREVIEW_URL_SERVICE_URL = "internal/service/url";
+  private static final String LIVE_URL_SERVICE_URL = "internal/service/url";
 
   public ContentLinkBuilder() {
   }

--- a/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/service/ContentLinkBuilder.java
+++ b/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/service/ContentLinkBuilder.java
@@ -23,8 +23,8 @@ import java.util.List;
  */
 public class ContentLinkBuilder {
   private static final Logger LOG = LoggerFactory.getLogger(ContentLinkBuilder.class);
-  private static final String PREVIEW_URL_SERVICE_URL = "internal/preview/previewurl";
-  private static final String LIVE_URL_SERVICE_URL = "internal/service/url";
+  private static final String PREVIEW_URL_SERVICE_URL = "blueprint/servlet/internal/service/url";
+  private static final String LIVE_URL_SERVICE_URL = "blueprint/servlet/internal/service/url";
 
   public ContentLinkBuilder() {
   }
@@ -75,11 +75,15 @@ public class ContentLinkBuilder {
     Gson gson = new Gson();
     String body = gson.toJson(params);
     String result = postLinks(serviceUrl, body);
+    List<String> links = new ArrayList<>();
+    if (result == null) {
+      LOG.warn("Could not retrieve URL for content "+body);
+      return links;
+    }
 
     List<UrlServiceResponseParams> urls = gson.fromJson(result, new TypeToken<List<UrlServiceResponseParams>>() {
     }.getType());
 
-    List<String> links = new ArrayList<>();
     for (UrlServiceResponseParams url : urls) {
       if(url.getUrl() == null) {
         continue;

--- a/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/service/ContentLinkBuilder.java
+++ b/feedback-hub-siteimprove-studio-lib/src/main/java/com/coremedia/blueprint/feedbackhub/siteimprove/service/ContentLinkBuilder.java
@@ -31,26 +31,7 @@ public class ContentLinkBuilder {
 
   @Nullable
   String buildPreviewLink(String baseUrl, String id) {
-    String url = baseUrl;
-    if (!url.endsWith("/")) {
-      url = url + "/";
-    }
-    String serviceUrl = url + PREVIEW_URL_SERVICE_URL;
-
-    UriComponents uriComponents = UriComponentsBuilder.fromUriString(serviceUrl)
-            .queryParam("id", IdHelper.parseContentId(id)).build();
-
-    String link = getLink(uriComponents.toUriString());
-    if (link != null && !link.startsWith("http")) {
-      link = uriComponents.getScheme() + ":" + link;
-    }
-
-    return link;
-  }
-
-  @Nullable
-  String buildLiveLink(String baseUrl, String id) {
-    List<String> urls = buildLiveLink(baseUrl, Collections.singletonList(id));
+    List<String> urls = buildLink(baseUrl, Collections.singletonList(id), PREVIEW_URL_SERVICE_URL);
     if(!urls.isEmpty()) {
       return urls.get(0);
     }
@@ -58,12 +39,22 @@ public class ContentLinkBuilder {
     return null;
   }
 
-  private List<String> buildLiveLink(String baseUrl, Iterable<String> ids) {
+  @Nullable
+  String buildLiveLink(String baseUrl, String id) {
+    List<String> urls = buildLink(baseUrl, Collections.singletonList(id), LIVE_URL_SERVICE_URL);
+    if(!urls.isEmpty()) {
+      return urls.get(0);
+    }
+
+    return null;
+  }
+
+  private List<String> buildLink(String baseUrl, Iterable<String> ids, String serviceUrlSuffix) {
     String fullUrl = baseUrl;
     if (!fullUrl.endsWith("/")) {
       fullUrl = fullUrl + "/";
     }
-    String serviceUrl = fullUrl + LIVE_URL_SERVICE_URL;
+    String serviceUrl = fullUrl + serviceUrlSuffix;
     UriComponents uriComponents = UriComponentsBuilder.fromUriString(serviceUrl).build();
 
     Collection<UrlServiceRequestParams> params = new ArrayList<>();
@@ -93,21 +84,6 @@ public class ContentLinkBuilder {
     }
 
     return links;
-  }
-
-  private String getLink(String serviceUrl) {
-    try {
-      URL url = new URL(serviceUrl);
-      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-      connection.setRequestMethod("GET");
-      connection.setDoInput(true);
-      connection.setUseCaches(false);
-      return IOUtils.toString(connection.getInputStream(), "utf-8");
-    } catch (Exception e) {
-      LOG.error("Failed to get links to CAE: {}", e.getMessage(), e);
-    }
-
-    return null;
   }
 
   private String postLinks(String serviceUrl, String body) {

--- a/feedback-hub-siteimprove-studio/src/main/joo/com/coremedia/blueprint/studio/feedbackhub/siteimprove/FeedbackHubSiteimprove.properties
+++ b/feedback-hub-siteimprove-studio/src/main/joo/com/coremedia/blueprint/studio/feedbackhub/siteimprove/FeedbackHubSiteimprove.properties
@@ -30,6 +30,7 @@ siteimprove_lose_score = You will <b>lose {0} points</b> with the current change
 
 siteimprove_last_crawl = Last checked:
 siteimprove_unknown = unknown
+siteimprove_not_crawled = not crawled yet
 
 siteimprove_issues_help = Fixing these issues will improve the score.
 siteimprove_issue = Issue

--- a/feedback-hub-siteimprove-studio/src/main/joo/com/coremedia/blueprint/studio/feedbackhub/siteimprove/FeedbackHubSiteimprove_de.properties
+++ b/feedback-hub-siteimprove-studio/src/main/joo/com/coremedia/blueprint/studio/feedbackhub/siteimprove/FeedbackHubSiteimprove_de.properties
@@ -29,6 +29,7 @@ siteimprove_lose_score = Sie <b>verlieren {0} Punkte</b> mit den aktuellen \u00C
 
 siteimprove_last_crawl = Letzte Pr\u00FCfung:
 siteimprove_unknown = unbekannt
+siteimprove_not_crawled = Noch nicht \u00FCberpr\u00FCft
 
 siteimprove_issues_help = Beheben Sie diese Probleme um die Bewertung zu verbessern.
 siteimprove_issue = Problem

--- a/feedback-hub-siteimprove-studio/src/main/joo/com/coremedia/blueprint/studio/feedbackhub/siteimprove/itemtypes/SiteimproveFooterBase.as
+++ b/feedback-hub-siteimprove-studio/src/main/joo/com/coremedia/blueprint/studio/feedbackhub/siteimprove/itemtypes/SiteimproveFooterBase.as
@@ -34,6 +34,8 @@ public class SiteimproveFooterBase extends FeedbackItemPanel {
       if (time > 0) {
         var date:Date = new Date(time);
         label = label + ": " + FeedbackHelper.getDateDiff(date);
+      } else{
+        label = label + ": " +resourceManager.getString('com.coremedia.blueprint.studio.feedbackhub.siteimprove.FeedbackHubSiteimprove', 'siteimprove_not_crawled');
       }
 
       return label;
@@ -47,6 +49,8 @@ public class SiteimproveFooterBase extends FeedbackItemPanel {
       if (time > 0) {
         var date:Date = new Date(time);
         label = label + ": " + FeedbackHelper.getDateDiff(date);
+      } else{
+        label = label + ": " +resourceManager.getString('com.coremedia.blueprint.studio.feedbackhub.siteimprove.FeedbackHubSiteimprove', 'siteimprove_not_crawled');
       }
 
       return label;


### PR DESCRIPTION
This is a small bugfix for the comparison tab. There where two issues:
- Compariosn tab was allways disbabled for published contents
- the CAE service url to retrieve URLs where somehow wrong 