### PR TITLE
Add contents write permission

### DIFF
--- a/.github/workflows/build-presales.yml
+++ b/.github/workflows/build-presales.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Since the default permissions for GitHub actions are restricted, so we need to activate them explicitly!

See also: https://docs.github.com/en/enterprise-cloud@latest/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token